### PR TITLE
Untracked composer.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .idea/*
 /vendor/
+composer.lock


### PR DESCRIPTION
Removed teh composer.lock file from remote repository, causing unnecessary conflicts on the content-has value